### PR TITLE
Remove remoteHostName from HTTPSession

### DIFF
--- a/README_clover.md
+++ b/README_clover.md
@@ -1,5 +1,17 @@
 This is a fork of: https://github.com/NanoHttpd/nanohttpd
 
-This fork adds the branch `nanohttpd-project-2.3.1.1`, based the upstream tag `nanohttpd-project-2.3.1` which fixes an Android closeguard warning that occurs handling GZIP encoding and updates the version to 2.3.1.1.
+Added branches:
 
-Version 2.3.1.1 is deployed to Clovers artifactory here: https://artifactory.corp.clover.com/artifactory/webapp/#/artifacts/browse/tree/General/libs-release-local/org/nanohttpd/nanohttpd/2.3.1.1/nanohttpd-2.3.1.1.jar. There is no automated way to deploy this repository to artifactory. It must be built and deployed manually.
+* **nanohttpd-project-2.3.1.1:**
+  Based the upstream tag `nanohttpd-project-2.3.1` which fixes an Android closeguard warning that
+  occurs handling GZIP encoding and updates the version to 2.3.1.1.
+* **nanohttpd-project-2.3.1.2:**
+  Based on `nanohttpd-project-2.3.1.2`, this branch avoids a long reverse DNS query on certain
+  routers when they are disconnected from the internet (notably some Tp-Link models). The reverse
+  DNS query would happen whenever a client connects to the server but the result of the query is
+  unused. The call to `InetAddress#getHostName()` is removed, as in the upstream commit cd37235.
+
+Version 2.3.1.2 is deployed to Clovers artifactory here:
+https://artifactory.corp.clover.com/artifactory/webapp/#/artifacts/browse/tree/General/libs-release-local/org/nanohttpd/nanohttpd/2.3.1.2/nanohttpd-2.3.1.2.jar.
+There is no automated way to deploy this repository to artifactory. It must be built and deployed
+manually.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.nanohttpd</groupId>
 		<artifactId>nanohttpd-project</artifactId>
-		<version>2.3.1.1</version>
+		<version>2.3.1.2</version>
 	</parent>
 	<artifactId>nanohttpd</artifactId>
 	<packaging>jar</packaging>

--- a/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
+++ b/core/src/main/java/fi/iki/elonen/NanoHTTPD.java
@@ -635,8 +635,6 @@ public abstract class NanoHTTPD {
 
         private String remoteIp;
 
-        private String remoteHostname;
-
         private String protocolVersion;
 
         public HTTPSession(TempFileManager tempFileManager, InputStream inputStream, OutputStream outputStream) {
@@ -649,8 +647,7 @@ public abstract class NanoHTTPD {
             this.tempFileManager = tempFileManager;
             this.inputStream = new BufferedInputStream(inputStream, HTTPSession.BUFSIZE);
             this.outputStream = outputStream;
-            this.remoteIp = inetAddress.isLoopbackAddress() || inetAddress.isAnyLocalAddress() ? "127.0.0.1" : inetAddress.getHostAddress().toString();
-            this.remoteHostname = inetAddress.isLoopbackAddress() || inetAddress.isAnyLocalAddress() ? "localhost" : inetAddress.getHostName().toString();
+            this.remoteIp = inetAddress.isLoopbackAddress() || inetAddress.isAnyLocalAddress() ? "127.0.0.1" : inetAddress.getHostAddress();
             this.headers = new HashMap<String, String>();
         }
 
@@ -1222,11 +1219,6 @@ public abstract class NanoHTTPD {
         public String getRemoteIpAddress() {
             return this.remoteIp;
         }
-
-        @Override
-        public String getRemoteHostName() {
-            return this.remoteHostname;
-        }
     }
 
     /**
@@ -1278,13 +1270,6 @@ public abstract class NanoHTTPD {
          * @return the IP address.
          */
         String getRemoteIpAddress();
-
-        /**
-         * Get the remote hostname of the requester.
-         * 
-         * @return the hostname.
-         */
-        String getRemoteHostName();
     }
 
     /**

--- a/core/src/test/java/fi/iki/elonen/HttpSessionHeadersTest.java
+++ b/core/src/test/java/fi/iki/elonen/HttpSessionHeadersTest.java
@@ -34,13 +34,11 @@ package fi.iki.elonen;
  */
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.net.InetAddress;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class HttpSessionHeadersTest extends HttpServerTest {
@@ -60,7 +58,6 @@ public class HttpSessionHeadersTest extends HttpServerTest {
         for (String ipAddress : ipAddresses) {
             InetAddress inetAddress = InetAddress.getByName(ipAddress);
             NanoHTTPD.HTTPSession session = this.testServer.createSession(HttpSessionHeadersTest.TEST_TEMP_FILE_MANAGER, inputStream, outputStream, inetAddress);
-            assertNotNull(ipAddress, session.getRemoteHostName());
             assertEquals(ipAddress, session.getRemoteIpAddress());
         }
     }

--- a/core/src/test/java/fi/iki/elonen/HttpSessionTest.java
+++ b/core/src/test/java/fi/iki/elonen/HttpSessionTest.java
@@ -49,24 +49,6 @@ public class HttpSessionTest extends HttpServerTest {
     private static final TestTempFileManager TEST_TEMP_FILE_MANAGER = new TestTempFileManager();
 
     @Test
-    public void testSessionRemoteHostnameLocalhost() throws UnknownHostException {
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(HttpSessionTest.DUMMY_REQUEST_CONTENT.getBytes());
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        InetAddress inetAddress = InetAddress.getByName("127.0.0.1");
-        NanoHTTPD.HTTPSession session = this.testServer.createSession(HttpSessionTest.TEST_TEMP_FILE_MANAGER, inputStream, outputStream, inetAddress);
-        assertEquals("localhost", session.getRemoteHostName());
-    }
-
-    @Test
-    public void testSessionRemoteHostname() throws UnknownHostException {
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(HttpSessionTest.DUMMY_REQUEST_CONTENT.getBytes());
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        InetAddress inetAddress = InetAddress.getByName("google.com");
-        NanoHTTPD.HTTPSession session = this.testServer.createSession(HttpSessionTest.TEST_TEMP_FILE_MANAGER, inputStream, outputStream, inetAddress);
-        assertEquals("google.com", session.getRemoteHostName());
-    }
-
-    @Test
     public void testSessionRemoteIPAddress() throws UnknownHostException {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(HttpSessionTest.DUMMY_REQUEST_CONTENT.getBytes());
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/fileupload/pom.xml
+++ b/fileupload/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>nanohttpd-project</artifactId>
 		<groupId>org.nanohttpd</groupId>
-		<version>2.3.1.1</version>
+		<version>2.3.1.2</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>nanohttpd-apache-fileupload</artifactId>
@@ -13,7 +13,7 @@
 		<dependency>
 			<groupId>org.nanohttpd</groupId>
 			<artifactId>nanohttpd</artifactId>
-			<version>2.3.1.1</version>
+			<version>2.3.1.2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/markdown-plugin/pom.xml
+++ b/markdown-plugin/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.nanohttpd</groupId>
 		<artifactId>nanohttpd-project</artifactId>
-		<version>2.3.1.1</version>
+		<version>2.3.1.2</version>
 	</parent>
 	<artifactId>nanohttpd-webserver-markdown-plugin</artifactId>
 	<packaging>jar</packaging>

--- a/nanolets/pom.xml
+++ b/nanolets/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.nanohttpd</groupId>
 		<artifactId>nanohttpd-project</artifactId>
-		<version>2.3.1.1</version>
+		<version>2.3.1.2</version>
 	</parent>
 	<artifactId>nanohttpd-nanolets</artifactId>
 	<packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<groupId>org.nanohttpd</groupId>
 	<artifactId>nanohttpd-project</artifactId>
-	<version>2.3.1.1</version>
+	<version>2.3.1.2</version>
 	<packaging>pom</packaging>
 	<name>NanoHttpd-Project</name>
 	<description>NanoHttpd is a light-weight HTTP server designed for embedding in other applications.</description>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.nanohttpd</groupId>
 		<artifactId>nanohttpd-project</artifactId>
-		<version>2.3.1.1</version>
+		<version>2.3.1.2</version>
 	</parent>
 	<artifactId>nanohttpd-samples</artifactId>
 	<description>samples for nanohttpd</description>

--- a/webserver/pom.xml
+++ b/webserver/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.nanohttpd</groupId>
 		<artifactId>nanohttpd-project</artifactId>
-		<version>2.3.1.1</version>
+		<version>2.3.1.2</version>
 	</parent>
 	<artifactId>nanohttpd-webserver</artifactId>
 	<packaging>jar</packaging>

--- a/websocket/pom.xml
+++ b/websocket/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.nanohttpd</groupId>
 		<artifactId>nanohttpd-project</artifactId>
-		<version>2.3.1.1</version>
+		<version>2.3.1.2</version>
 	</parent>
 	<artifactId>nanohttpd-websocket</artifactId>
 	<packaging>jar</packaging>


### PR DESCRIPTION
It can take too long to determine the host name via DNS. Some routers do not respond quickly, especially if they are disconnected from the internet. Trying to connect to a peer on the local network while a router is offline can result in 10+ second delays and connection timeouts.

Similar to the upstream commit cd37235